### PR TITLE
add: [plugins] hashlookup plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cert-lv/graphoscope
 go 1.16
 
 require (
+	github.com/Jeffail/gabs/v2 v2.7.0 // indirect
 	github.com/blastrain/vitess-sqlparser v0.0.0-20201030050434-a139afbb1aba
 	github.com/georgysavva/scany v0.2.7
 	github.com/go-sql-driver/mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Jeffail/gabs/v2 v2.7.0 h1:Y2edYaTcE8ZpRsR2AtmPu5xQdFDIthFG0jYhu5PY8kg=
+github.com/Jeffail/gabs/v2 v2.7.0/go.mod h1:dp5ocw1FvBBQYssgHsG7I1WYsiLRtkUaB1FEtSwvNUw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=

--- a/plugins/src/hashlookup/README.md
+++ b/plugins/src/hashlookup/README.md
@@ -1,0 +1,22 @@
+# Hashlookup plugin
+
+Plugin to query [hashlookup services](https://github.com/hashlookup).
+For instance hashlookup.circl.lu
+
+Sample command to use plugin:
+```sh
+curl 'https://localhost:443/api?uuid=auth-key&sql=FROM+hashlookup+WHERE+sha1=%27deac5aeda66017c25a9e21f36f5ee618d2ad9d3d%27'
+```
+
+Compile with:
+```sh
+go build -buildmode=plugin -ldflags="-w" -o hashlookup.so ./*.go
+```
+Or use the Makefile command:
+`make plugins-local`
+
+# Access details
+
+Source YAML definition's `access` fields:
+- **url**: hashlookup API endpoint, for example - `https://hashlookup.circl.lu`
+- **apiKey**: optional hashlookup API key

--- a/plugins/src/hashlookup/README.md
+++ b/plugins/src/hashlookup/README.md
@@ -20,3 +20,55 @@ Or use the Makefile command:
 Source YAML definition's `access` fields:
 - **url**: hashlookup API endpoint, for example - `https://hashlookup.circl.lu`
 - **apiKey**: optional hashlookup API key
+
+# Example definition file
+
+```yaml
+name: hashlookup
+label: Hashlookup
+icon: database
+
+plugin: hashlookup
+inGlobal: true
+includeDatetime: false
+supportsSQL: false
+
+access:
+    url: https://hashlookup.circl.lu
+    apiKey: .
+
+
+relations:
+  -
+    from:
+        id: SHA-1
+        group: identifier
+        search: sha1
+        attributes: ["FileName", "FileSize", "source-url","MD5" ,"SHA-512" , "SHA-256", "SHA-1", "SSDEEP", "TLSH", "insert-timestamp", "mimetype", "source", "hashlookup-parent-total", "snap-authority"]
+
+    to:
+        id: parent
+        group: identifier
+        search: sha1
+        attributes: ["FileName", "FileSize", "source-url","MD5" ,"SHA-512" , "SHA-256", "SHA-1", "SSDEEP", "TLSH", "insert-timestamp", "mimetype", "source", "hashlookup-parent-total", "snap-authority"]
+
+    edge:
+        label: ChildOf
+        attributes: []
+  -
+    from:
+      id: SHA-1
+      group: identifier
+      search: sha1
+      attributes: ["FileName", "FileSize", "source-url","MD5" ,"SHA-512" , "SHA-256", "SHA-1", "SSDEEP", "TLSH", "insert-timestamp", "mimetype", "source", "hashlookup-parent-total", "snap-authority"]
+
+    to:
+      id: children
+      group: identifier
+      search: sha1
+      attributes: ["FileName", "FileSize", "source-url","MD5" ,"SHA-512" , "SHA-256", "SHA-1", "SSDEEP", "TLSH", "insert-timestamp", "mimetype", "source", "hashlookup-parent-total", "snap-authority"]
+
+    edge:
+      label: ParentOf
+      attributes: []
+```

--- a/plugins/src/hashlookup/README.md
+++ b/plugins/src/hashlookup/README.md
@@ -31,12 +31,16 @@ icon: database
 plugin: hashlookup
 inGlobal: true
 includeDatetime: false
-supportsSQL: false
+supportsSQL: true
 
 access:
     url: https://hashlookup.circl.lu
     apiKey: .
 
+queryFields:
+    - md5
+    - sha1
+    - sha256
 
 relations:
   -
@@ -71,4 +75,38 @@ relations:
     edge:
       label: ParentOf
       attributes: []
+
+  -
+    from:
+        id: SHA-1
+        group: identifier
+        search: sha1
+        attributes: ["FileName", "FileSize", "source-url","MD5" ,"SHA-
+512" , "SHA-256", "SHA-1", "SSDEEP", "TLSH", "insert-timestamp",
+"mimetype", "source", "hashlookup-parent-total", "snap-authority"]
+
+    to:
+        id: MD5
+        group: identifier
+        search: md5
+        attributes: ["FileName", "FileSize", "source-url","MD5" ,"SHA-
+512" , "SHA-256", "SHA-1", "SSDEEP", "TLSH", "insert-timestamp",
+"mimetype", "source", "hashlookup-parent-total", "snap-authority"]
+
+  -
+    from:
+        id: SHA-1
+        group: identifier
+        search: sha1
+        attributes: ["FileName", "FileSize", "source-url","MD5" ,"SHA-
+512" , "SHA-256", "SHA-1", "SSDEEP", "TLSH", "insert-timestamp",
+"mimetype", "source", "hashlookup-parent-total", "snap-authority"]
+
+    to:
+        id: SHA-256
+        group: identifier
+        search: sha256
+        attributes: ["FileName", "FileSize", "source-url","MD5" ,"SHA-
+512" , "SHA-256", "SHA-1", "SSDEEP", "TLSH", "insert-timestamp",
+"mimetype", "source", "hashlookup-parent-total", "snap-authority"]
 ```

--- a/plugins/src/hashlookup/convert.go
+++ b/plugins/src/hashlookup/convert.go
@@ -1,0 +1,40 @@
+/*
+ * SQL to MongoDB query convertor
+ */
+
+package main
+
+import (
+	"errors"
+	"github.com/blastrain/vitess-sqlparser/sqlparser"
+)
+
+/*
+ * Convert SQL statement to the object expected by the data source
+ */
+func (p *plugin) convert(sel *sqlparser.Select) ([][2]string, error) {
+
+	// Handle WHERE.
+	// Top level node pass in an empty interface
+	// to tell the children this is root.
+	// Is there any better way?
+	var rootParent sqlparser.Expr
+
+	// List of requested fields & values
+	fields, err := handleSelectWhere(&sel.Where.Expr, true, &rootParent)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle GROUP BY
+	if len(sel.GroupBy) > 0 || checkNeedAgg(sel.SelectExprs) {
+		return nil, errors.New("'GROUP BY' & aggregation are not supported")
+	}
+
+	// Set LIMIT
+	if sel.Limit != nil {
+		fields = append(fields, [2]string{"limit", sqlparser.String(sel.Limit.Rowcount)})
+	}
+
+	return fields, nil
+}

--- a/plugins/src/hashlookup/hashlookup.go
+++ b/plugins/src/hashlookup/hashlookup.go
@@ -1,0 +1,492 @@
+/*
+ * Template to develop new plugins.
+ * Check GUI documentation section "Administration" for a step-by-step workflow
+ */
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/Jeffail/gabs/v2"
+	"github.com/blastrain/vitess-sqlparser/sqlparser"
+	"github.com/cert-lv/graphoscope/pdk"
+	"github.com/umpc/go-sortedmap"
+	"github.com/umpc/go-sortedmap/desc"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+/*
+ * Check "pdk/plugin.go" for the built-in plugin functions description
+ */
+
+func (p *plugin) Source() *pdk.Source {
+	return p.source
+}
+
+func (p *plugin) Setup(source *pdk.Source, limit int) error {
+
+	// Validate necessary parameters
+	if source.Access["url"] == "" {
+		return fmt.Errorf("'access.url' is not defined")
+	} else if source.Access["url"][0:4] != "http" {
+		return fmt.Errorf("'access.url' must start with 'http[s]://'")
+	}
+
+	// Store settings
+	p.source = source
+	p.limit = limit
+	p.url = source.Access["url"]
+
+	// Set possible variable type & searching fields
+	for _, relation := range source.Relations {
+		for _, types := range relation.From.VarTypes {
+			types.RegexCompiled = regexp.MustCompile(types.Regex)
+		}
+
+		for _, types := range relation.To.VarTypes {
+			types.RegexCompiled = regexp.MustCompile(types.Regex)
+		}
+	}
+
+	fmt.Printf("HTTP %s: %#v\n\n", source.Name, p)
+	return nil
+}
+
+func (p *plugin) Search(stmt *sqlparser.Select) ([]map[string]interface{}, map[string]interface{}, error) {
+
+	// Storage for the results to return
+	results := []map[string]interface{}{}
+
+	searchFields, err := p.convert(stmt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var bodies []*bytes.Buffer
+
+	/*
+	 * Send indicators to get results back
+	 */
+	bodies, err = p.request(searchFields)
+	var unpacked []string
+	if err != nil {
+		return nil, nil, err
+	}
+
+	/*
+	 * Receive hits and deserialize them
+	 */
+
+	// Attempt to unpack arrays if we get results from the bulk endpoint
+	for _, body := range bodies {
+		jsonParsed, err := gabs.ParseJSONBuffer(body)
+		if err != nil {
+			return nil, nil, err
+		}
+		childM := jsonParsed.ChildrenMap()
+		// If SHA-1 is present, this is not an array
+		if _, ok := childM["SHA-1"]; ok {
+			unpacked = append(unpacked, jsonParsed.String())
+		} else {
+			// Unpack the Array from bulk
+			childA := jsonParsed.Children()
+			for _, child := range childA {
+				unpacked = append(unpacked, child.String())
+			}
+		}
+	}
+
+	// variable holding the Json values for the merge
+	var finalJSONParsed = gabs.New()
+	finalJSONParsed.Array("entries")
+	// variable used to convert back to go
+	var entries []map[string]interface{}
+
+	for _, body := range unpacked {
+		// Struct to store statistics data
+		// when the amount of returned entries is too large
+		stats := pdk.NewStats()
+
+		for _, field := range p.source.StatsFields {
+			stats.Fields[field] = sortedmap.New(10, desc.Int)
+		}
+
+		jsonParsed, err := gabs.ParseJSON([]byte(body))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		entryObj := gabs.New()
+		entryObj.Array("entries")
+
+		children := new(gabs.Container)
+		parents := new(gabs.Container)
+
+		// TODO fetch children / parents according to the LIMIT
+		// if the children/parent key exist and the count hits hashlookup limits,
+		// we query hashlookup again up the the query' LIMIT
+
+		if jsonParsed.Exists("children") {
+			if err != nil {
+				return nil, nil, err
+			}
+			// Here we run the new query
+			gabsChildren, err := p.getRelated("children", jsonParsed.S("SHA-1").Data().(string), p.limit)
+			if err != nil {
+				return nil, nil, err
+			}
+			children = gabsChildren.Path("children")
+			for _, child := range children.Children() {
+				// Create an object from the child
+				jsonObj := gabs.New()
+				// Add a reference to the parent
+				jsonObj.Set(jsonParsed.S("SHA-1").Data(), "parent")
+				jsonObj.Set(child.Data().(string), "SHA-1")
+				// Add the children to the list of entries
+				entryObj.ArrayAppend(jsonObj, "entries")
+			}
+			// Remove the children for the main received object
+			jsonParsed.Delete("children")
+		}
+		if jsonParsed.Exists("parents") {
+			// Here we run the new query
+			gabsParents, err := p.getRelated("parents", jsonParsed.S("SHA-1").Data().(string), p.limit)
+			if err != nil {
+				return nil, nil, err
+			}
+			parents = gabsParents.Path("parents")
+			if err != nil {
+				return nil, nil, err
+			}
+			for _, child := range parents.Children() {
+				// Create an object from the parent
+				jsonObj := gabs.New()
+				// Add a reference to the children
+				jsonObj.Set(jsonParsed.S("SHA-1").Data(), "children")
+				jsonObj.Set(child.Data().(string), "SHA-1")
+				// Add the children to the list of entries
+				entryObj.ArrayAppend(jsonObj, "entries")
+			}
+			// Remove the parents for the main received object
+			jsonParsed.Delete("parents")
+		}
+
+		entryObj.ArrayAppend(jsonParsed, "entries")
+
+		finalJSONParsed.Merge(entryObj)
+	}
+
+	err = json.NewDecoder(strings.NewReader(finalJSONParsed.S("entries").String())).Decode(&entries)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mx := sync.Mutex{}
+	umx := sync.Mutex{}
+	unique := make(map[string]bool)
+	counter := 0
+
+	// Struct to store statistics data
+	// when the amount of returned entries is too large
+	stats := pdk.NewStats()
+
+	for _, field := range p.source.StatsFields {
+		stats.Fields[field] = sortedmap.New(10, desc.Int)
+	}
+
+	for _, entry := range entries {
+
+		// Stop when results count is over the limit
+		if counter >= p.limit {
+			// Uncomment in real plugin
+			//cancel()
+
+			top, err := stats.ToJSON(p.source.Name)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			return nil, top, nil
+		}
+
+		// Update stats
+		for _, field := range p.source.StatsFields {
+			stats.Update(entry, field)
+		}
+
+		// Go through all the predefined relations and collect unique entries
+		for _, relation := range p.source.Relations {
+			if entry[relation.From.ID] != nil && entry[relation.To.ID] != nil {
+				umx.Lock()
+				if _, exists := unique[entry[relation.From.ID].(string)+entry[relation.To.ID].(string)]; exists {
+					if pdk.ResultsContain(results, entry, relation) {
+						umx.Unlock()
+						continue
+					}
+				}
+
+				counter++
+
+				unique[entry[relation.From.ID].(string)+entry[relation.To.ID].(string)] = true
+				umx.Unlock()
+
+				/*
+				 * FROM node with attributes
+				 */
+				from := map[string]interface{}{
+					"id":     entry[relation.From.ID],
+					"group":  relation.From.Group,
+					"search": relation.From.Search,
+				}
+
+				// Check FROM type & searching fields
+				if len(relation.From.VarTypes) > 0 {
+					for _, t := range relation.From.VarTypes {
+						if t.RegexCompiled.MatchString(entry[relation.From.ID].(string)) {
+							from["group"] = t.Group
+							from["search"] = t.Search
+
+							break
+						}
+					}
+				}
+
+				if len(relation.From.Attributes) > 0 {
+					from["attributes"] = make(map[string]interface{})
+					pdk.CopyPresentValues(entry, from["attributes"].(map[string]interface{}), relation.From.Attributes)
+				}
+
+				/*
+				 * TO node
+				 */
+				to := map[string]interface{}{
+					"id":     entry[relation.To.ID],
+					"group":  relation.To.Group,
+					"search": relation.To.Search,
+				}
+
+				// Check FROM type & searching fields
+				if len(relation.To.VarTypes) > 0 {
+					for _, t := range relation.To.VarTypes {
+						if t.RegexCompiled.MatchString(entry[relation.To.ID].(string)) {
+							to["group"] = t.Group
+							to["search"] = t.Search
+
+							break
+						}
+					}
+				}
+
+				if len(relation.To.Attributes) > 0 {
+					to["attributes"] = make(map[string]interface{})
+					pdk.CopyPresentValues(entry, to["attributes"].(map[string]interface{}), relation.To.Attributes)
+				}
+
+				// Resulting graph entry to return
+				result := make(map[string]interface{})
+
+				/*
+				 * Edge between FROM and TO
+				 */
+				if relation.Edge != nil && (relation.Edge.Label != "" || len(relation.Edge.Attributes) > 0) {
+					result["edge"] = make(map[string]interface{})
+
+					if relation.Edge.Label != "" {
+						result["edge"].(map[string]interface{})["label"] = relation.Edge.Label
+					}
+
+					if len(relation.Edge.Attributes) > 0 {
+						pdk.CopyPresentValues(entry, result["edge"].(map[string]interface{}), relation.Edge.Attributes)
+					}
+				}
+
+				/*
+				 * Put it together
+				 */
+				result["from"] = from
+				result["to"] = to
+				result["source"] = p.source.Name
+
+				//fmt.Println("Edge:", from, to)
+
+				/*
+				 * Add current entry to the list to return
+				 */
+				mx.Lock()
+				results = append(results, result)
+				mx.Unlock()
+			}
+		}
+	}
+
+	return results, nil, nil
+}
+
+// request connects to the HTTP access point and returns the response
+func (p *plugin) request(searchFields [][2]string) ([]*bytes.Buffer, error) {
+	// Create a request body
+	data := url.Values{}
+
+	// List of possible Hashlookup fields
+	possibleFields := []string{"md5", "sha1", "sha256"}
+	// List of requests we will have to make
+	requests := make([]*http.Request, 0, 3)
+	responses := make([]*bytes.Buffer, 0, 3)
+
+	for _, field := range searchFields {
+		data.Add(field[0], field[1])
+	}
+
+	for _, possibleSearchField := range possibleFields {
+		// Check what endpoints we hit
+		if data.Has(possibleSearchField) {
+			tmpUrl := ""
+			var tmpReq *http.Request
+			var err error
+
+			if len(data[possibleSearchField]) > 1 {
+				tmpUrl = p.url + "/bulk/" + possibleSearchField
+				tmpMap := make(map[string][]string)
+				tmpMap["hashes"] = data[possibleSearchField]
+				tmpBody, errm := json.Marshal(tmpMap)
+				if errm != nil {
+					return nil, fmt.Errorf("Could not serialize: %s", err.Error())
+				}
+				tmpReq, err = http.NewRequest("POST", tmpUrl, bytes.NewReader(tmpBody))
+			} else {
+				tmpUrl = p.url + "/lookup/" + possibleSearchField + "/" + data.Get(possibleSearchField)
+				tmpReq, err = http.NewRequest("GET", tmpUrl, nil)
+			}
+			requests = append(requests, tmpReq)
+
+			if err != nil {
+				return nil, fmt.Errorf("Can't create the request: %s", err.Error())
+			}
+		}
+	}
+	// If no possible search field, exit
+	if len(requests) == 0 {
+		return nil, fmt.Errorf("%s", errors.New("No compatible hashlookup search field."))
+	}
+
+	for _, req := range requests {
+		// Set basic auth credentials if given
+		if p.source.Access["apiKey"] != "" {
+			req.SetBasicAuth(p.source.Access["apiKey"], "")
+		}
+		req.Header.Add("Content-Type", "application/json")
+		// Declare an HTTP client to execute the request
+		client := http.Client{Timeout: p.source.Timeout}
+		// Send an HTTP using `req` object
+		tmpResp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("Can't do an HTTP request: %s", err.Error())
+		}
+
+		tmpBody := &bytes.Buffer{}
+		_, err = tmpBody.ReadFrom(tmpResp.Body)
+		if err != nil {
+			tmpResp.Body.Close()
+			return nil, fmt.Errorf("Can't read an HTTP response: %s", err.Error())
+		}
+		tmpResp.Body.Close()
+		// Check the response
+		if tmpResp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("Bad response StatusCode: %s", tmpResp.Status)
+		}
+		responses = append(responses, tmpBody)
+	}
+
+	return responses, nil
+}
+
+// getChildren connect to the HTTP endpoints and retrieve children
+func (p *plugin) getRelated(relation string, parent string, limit int) (*gabs.Container, error) {
+	fmt.Println(relation)
+
+	// Do everything as float64 as shortcut because it's gabs's default
+	var nbElements, total, spoon float64
+	gabsBuffer := gabs.New()
+	gabsBuffer.Array(relation)
+	var err error
+
+	// How many records we want at once
+	spoon = 99
+	url := ""
+	cursor := "0"
+	total = spoon
+
+	for (nbElements < float64(limit)) && (nbElements < total) {
+		fmt.Println(nbElements)
+		url = p.url + "/" + relation + "/" + parent + "/" + fmt.Sprint(spoon) + "/" + cursor
+		fmt.Println(url)
+		body, err := p.query(url)
+		if err != nil {
+			return nil, fmt.Errorf("Can't query %s", err.Error())
+		}
+		tmp, err := gabs.ParseJSONBuffer(body)
+		if err != nil {
+			return nil, fmt.Errorf("Can't parse: %s", err.Error())
+		}
+		gabsBuffer.Merge(tmp)
+		cursor = tmp.Path("cursor").Data().(string)
+		total, _ = tmp.Path("total").Data().(float64)
+		nbElements += spoon
+	}
+
+	return gabsBuffer, err
+}
+
+func (p *plugin) Stop() error {
+	/*
+	 * STEP 8.
+	 *
+	 * Stop the plugin when main service stops,
+	 * drop all connections correctly
+	 */
+
+	// ctx, cancel := context.WithTimeout(context.Background(), p.source.Timeout)
+	// defer cancel()
+
+	// return p.client.Disconnect(ctx)
+	return nil
+}
+
+func (p *plugin) query(url string) (*bytes.Buffer, error) {
+
+	req, err := http.NewRequest("GET", url, nil)
+
+	// Set basic auth credentials if given
+	if p.source.Access["apiKey"] != "" {
+		req.SetBasicAuth(p.source.Access["apiKey"], "")
+	}
+	req.Header.Add("Content-Type", "application/json")
+	// Declare an HTTP client to execute the request
+	client := http.Client{Timeout: p.source.Timeout}
+	// Send an HTTP using `req` object
+	response, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Can't do an HTTP request: %s", err.Error())
+	}
+
+	body := &bytes.Buffer{}
+	_, err = body.ReadFrom(response.Body)
+	if err != nil {
+		response.Body.Close()
+		return nil, fmt.Errorf("Can't read an HTTP response: %s", err.Error())
+	}
+	response.Body.Close()
+	// Check the response
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Bad response StatusCode: %s", response.Status)
+	}
+
+	return body, err
+}

--- a/plugins/src/hashlookup/hashlookup_test.go
+++ b/plugins/src/hashlookup/hashlookup_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/blastrain/vitess-sqlparser/sqlparser"
+)
+
+/*
+ * Test SQL conversion to the data source's expected format
+ */
+func TestConvert(t *testing.T) {
+
+	// Empty plugin's instance to test
+	c := plugin{}
+
+	// Pairs of SQLs and the expected results
+	tables := []struct {
+		sql       string
+		converted [][2]string
+	}{
+		{`SELECT * WHERE sha1='DEAC5AEDA66017C25A9E21F36F5EE618D2AD9D3D'`, [][2]string{[2]string{"sha1", "DEAC5AEDA66017C25A9E21F36F5EE618D2AD9D3D"}}},
+	}
+
+	for _, table := range tables {
+		// Executed by the main service
+		ast, err := sqlparser.Parse(table.sql)
+		if err != nil {
+			t.Errorf("Can't parse '%s': %s", table.sql, err.Error())
+			continue
+		}
+
+		stmt, ok := ast.(*sqlparser.Select)
+		if !ok {
+			t.Errorf("Only SELECT statement is allowed: %s", table.sql)
+			continue
+		}
+
+		// Executed by the plugin
+		result, err := c.convert(stmt)
+		if err != nil {
+			t.Errorf("Can't convert '%s': %s", table.sql, err.Error())
+			continue
+		}
+
+		if !equal(result, table.converted) {
+			t.Errorf("Invalid conversion of \"%s\": \"%s\", expected: \"%s\"", table.sql, result, table.converted)
+		}
+	}
+}
+
+/*
+ * Check whether a and b slices contain the same elements
+ */
+func equal(a, b [][2]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/plugins/src/hashlookup/plugin.go
+++ b/plugins/src/hashlookup/plugin.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"github.com/cert-lv/graphoscope/pdk"
+)
+
+/*
+ * Export symbols
+ */
+var (
+	Name    = "hashlookup"
+	Version = "1.0.0"
+	Plugin  plugin
+)
+
+/*
+ * Structure to be imported by the core as a plugin
+ */
+type plugin struct {
+
+	// Inherit default configuration fields
+	source *pdk.Source
+
+	//client *package.Client
+	limit int
+
+	// Custom fields
+	url    string
+	apiKey string
+}

--- a/plugins/src/hashlookup/select.go
+++ b/plugins/src/hashlookup/select.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/blastrain/vitess-sqlparser/sqlparser"
+)
+
+// If the where is empty, need to check whether to agg or not
+func checkNeedAgg(sqlSelect sqlparser.SelectExprs) bool {
+	for _, v := range sqlSelect {
+		expr, ok := v.(*sqlparser.AliasedExpr)
+		if !ok {
+			// No need to handle, star expression * just skip is ok
+			continue
+		}
+
+		// TODO: more precise
+		if _, ok := expr.Expr.(*sqlparser.FuncExpr); ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func handleSelectWhereComparisonExpr(expr *sqlparser.Expr, topLevel bool, parent *sqlparser.Expr) ([][2]string, error) {
+	comparisonExpr := (*expr).(*sqlparser.ComparisonExpr)
+	colName, ok := comparisonExpr.Left.(*sqlparser.ColName)
+
+	if !ok {
+		return nil, errors.New("Invalid comparison expression, the left must be a column name")
+	}
+
+	colNameStr := sqlparser.String(colName)
+	colNameStr = strings.Replace(colNameStr, "`", "", -1)
+	rightIntf, err := buildComparisonExprRightStr(comparisonExpr.Right)
+	if err != nil {
+		return nil, err
+	}
+
+	fields := [][2]string{}
+
+	switch comparisonExpr.Operator {
+	case "=":
+		fields = append(fields, [2]string{colNameStr, fmt.Sprintf("%s", rightIntf)})
+	default:
+		return nil, errors.New("'=' operator is supported only")
+	}
+
+	return fields, nil
+}
+
+func handleSelectWhereAndExpr(expr *sqlparser.Expr, topLevel bool, parent *sqlparser.Expr) ([][2]string, error) {
+	andExpr := (*expr).(*sqlparser.AndExpr)
+	leftExpr := andExpr.Left
+	rightExpr := andExpr.Right
+
+	leftStr, err := handleSelectWhere(&leftExpr, false, expr)
+	if err != nil {
+		return nil, err
+	}
+
+	rightStr, err := handleSelectWhere(&rightExpr, false, expr)
+	if err != nil {
+		return nil, err
+	}
+
+	fields := append(leftStr, rightStr...)
+	if topLevel {
+		fields = append(fields, [2]string{"operator", "and"})
+	}
+
+	return fields, nil
+}
+
+func handleSelectWhereOrExpr(expr *sqlparser.Expr, topLevel bool, parent *sqlparser.Expr) ([][2]string, error) {
+	orExpr := (*expr).(*sqlparser.OrExpr)
+	leftExpr := orExpr.Left
+	rightExpr := orExpr.Right
+
+	leftStr, err := handleSelectWhere(&leftExpr, false, expr)
+	if err != nil {
+		return nil, err
+	}
+
+	rightStr, err := handleSelectWhere(&rightExpr, false, expr)
+	if err != nil {
+		return nil, err
+	}
+
+	fields := append(leftStr, rightStr...)
+	if topLevel {
+		fields = append(fields, [2]string{"operator", "or"})
+	}
+
+	return fields, nil
+}
+
+// Between a and b.
+// The meaning is equal to range query
+func handleSelectWhereBetweenExpr(expr *sqlparser.Expr, topLevel bool) ([][2]string, error) {
+	rangeCond := (*expr).(*sqlparser.RangeCond)
+	colName, ok := rangeCond.Left.(*sqlparser.ColName)
+
+	if !ok {
+		return nil, errors.New("Range column name missing")
+	}
+
+	//colNameStr := sqlparser.String(colName)
+	colNameStr := strings.Trim(sqlparser.String(colName), "`")
+	//fromStr := strings.Trim(sqlparser.String(rangeCond.From), "'")
+	//toStr := strings.Trim(sqlparser.String(rangeCond.To), "'")
+
+	var from string
+	var to string
+
+	// Prepare a 'From' value
+	switch expr := rangeCond.From.(type) {
+	case *sqlparser.SQLVal:
+		switch expr.Type {
+		case sqlparser.IntVal, sqlparser.FloatVal, sqlparser.StrVal:
+			from = string(expr.Val)
+		default:
+			return nil, fmt.Errorf("Invalid BETWEEN 'from' value: %v (type %v)", string(expr.Val), expr.Type)
+		}
+	default:
+		return nil, fmt.Errorf("Invalid BETWEEN 'from' value: %v", strings.Trim(sqlparser.String(rangeCond.From), "'"))
+	}
+
+	// Prepare a 'To' value
+	switch expr := rangeCond.To.(type) {
+	case *sqlparser.SQLVal:
+		switch expr.Type {
+		case sqlparser.IntVal, sqlparser.FloatVal, sqlparser.StrVal:
+			to = string(expr.Val)
+		default:
+			return nil, fmt.Errorf("Invalid BETWEEN 'to' value: %v (type %v)", string(expr.Val), expr.Type)
+		}
+	default:
+		return nil, fmt.Errorf("Invalid BETWEEN 'to' value: %v", strings.Trim(sqlparser.String(rangeCond.To), "'"))
+	}
+
+	// Build resulting fields list
+	var fields [][2]string
+	fields = append(fields, [2]string{colNameStr + "_from", from})
+	fields = append(fields, [2]string{colNameStr + "_to", to})
+
+	return fields, nil
+}
+
+func handleSelectWhereParenExpr(expr *sqlparser.Expr, topLevel bool, parent *sqlparser.Expr) ([][2]string, error) {
+	parentBoolExpr := (*expr).(*sqlparser.ParenExpr)
+	boolExpr := parentBoolExpr.Expr
+
+	// If parent is the top level, bool must is needed
+	var isThisTopLevel = false
+	if topLevel {
+		isThisTopLevel = true
+	}
+
+	return handleSelectWhere(&boolExpr, isThisTopLevel, parent)
+}
+
+func buildNestedFuncStrValue(nestedFunc *sqlparser.FuncExpr) (string, error) {
+	return "", errors.New("Unsupported function: " + nestedFunc.Name.String())
+}
+
+func buildComparisonExprRightStr(expr sqlparser.Expr) (interface{}, error) {
+	var rightStr string
+	var err error
+
+	switch expr := expr.(type) {
+	case *sqlparser.SQLVal:
+		// Use string value type only
+		rightStr = sqlparser.String(expr)
+		rightStr = strings.Trim(rightStr, "'")
+
+	case *sqlparser.BoolVal, sqlparser.BoolVal:
+		rightStr = sqlparser.String(expr)
+
+	case *sqlparser.GroupConcatExpr:
+		return nil, errors.New("group_concat not supported")
+
+	case *sqlparser.FuncExpr:
+		// Parse nested
+		//funcExpr := expr.(*sqlparser.FuncExpr)
+		//rightStr, err = buildNestedFuncStrValue(funcExpr)
+		rightStr, err = buildNestedFuncStrValue(expr)
+		if err != nil {
+			return nil, err
+		}
+
+	case *sqlparser.ColName:
+		if sqlparser.String(expr) == "exist" {
+			return nil, errors.New("'exist' expression currently not supported")
+		}
+		return nil, errors.New("Column name on the right side of compare operator is not supported")
+
+	case sqlparser.ValTuple:
+		rightStr = sqlparser.String(expr)
+
+	default:
+		return nil, fmt.Errorf("Unexpected SQL expression right part's type: %T", expr)
+	}
+
+	return rightStr, err
+}
+
+func handleSelectWhere(expr *sqlparser.Expr, topLevel bool, parent *sqlparser.Expr) ([][2]string, error) {
+	if expr == nil {
+		return nil, errors.New("SQL expression cannot be nil here")
+	}
+
+	switch (*expr).(type) {
+	case *sqlparser.ComparisonExpr:
+		return handleSelectWhereComparisonExpr(expr, topLevel, parent)
+
+	case *sqlparser.AndExpr:
+		return handleSelectWhereAndExpr(expr, topLevel, parent)
+
+	case *sqlparser.OrExpr:
+		return handleSelectWhereOrExpr(expr, topLevel, parent)
+
+	case *sqlparser.IsExpr:
+		return nil, errors.New("'is' expression currently not supported")
+
+	case *sqlparser.NotExpr:
+		return nil, errors.New("'not' expression currently not supported")
+
+	case *sqlparser.RangeCond:
+		return handleSelectWhereBetweenExpr(expr, topLevel)
+
+	case *sqlparser.ParenExpr:
+		return handleSelectWhereParenExpr(expr, topLevel, parent)
+	}
+
+	return nil, fmt.Errorf("Unexpected SQL expression type received: %T", *expr)
+}


### PR DESCRIPTION
Hi there, here is the hashlookup plugin come back from the dead after the forced push episode. From a helicopter view, it may make sense to remove everything related to SQL and keep it as simple as possible.

It does not work anymore and I don't really get why:

![graphoscope-hashlookup](https://github.com/cert-lv/graphoscope/assets/329725/a1e677be-7f09-4a48-a9aa-c275fdd8ffc6)